### PR TITLE
add TARGET_CLOUD and use in user-service

### DIFF
--- a/user-service/identity-pool.yml
+++ b/user-service/identity-pool.yml
@@ -9,7 +9,7 @@ Resources:
             Ref: CognitoUserPoolClient
           ProviderName:
             Fn::GetAtt: [ "CognitoUserPool", "ProviderName" ]
-            
+
   CognitoIdentityPoolRoles:
     Type: AWS::Cognito::IdentityPoolRoleAttachment
     Properties:
@@ -18,7 +18,7 @@ Resources:
       Roles:
         authenticated:
           Fn::GetAtt: [CognitoAuthRole, Arn]
-          
+
   CognitoAuthRole:
     Type: AWS::IAM::Role
     Properties:
@@ -58,7 +58,7 @@ Resources:
                   Fn::Join:
                     - ''
                     -
-                      - 'arn:aws:execute-api:'
+                      - 'arn:${self:custom.cloud}:execute-api:'
                       - Ref: AWS::Region
                       - ':'
                       - Ref: AWS::AccountId

--- a/user-service/serverless.yml
+++ b/user-service/serverless.yml
@@ -4,6 +4,7 @@ plugins:
   - serverless-dotenv-plugin
 custom:
   accountid: ${env:AWS_ACCOUNT_ID}
+  cloud: ${env:TARGET_CLOUD}
   region: ${env:TARGET_REGION}
   stage: ${self:provider.stage}
   dotenv:
@@ -18,3 +19,4 @@ provider:
 resources:
   - ${file(./user-pool.yml)}
   - ${file(./identity-pool.yml)}
+


### PR DESCRIPTION
add TARGET_CLOUD and use in user-service.
NOTE: user-service involves Cognito.
We currently do not deploy and use Cognito in AWS CN.
This is just so we have the right deployment templates in place in case we need it.